### PR TITLE
Pint token v0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Keg Tokens (KEG)
+# Beer Tokens (KEG & PINT)
 
-Every Keg Token is redeamable for a 5 gallon keg from The Doc.
+Every Keg Token (KEG) is redeamable for a 5 gallon keg from The Doc.
+
+Every Pint Token (PINT) is redeamable for a 1 pint from a keg.
 
 - 1 KEG = 5 Gallons
 - 0.1  KEG = 5 Pints
@@ -12,23 +14,28 @@ Every Keg Token is redeamable for a 5 gallon keg from The Doc.
 2. Setup Metamask wallet
 3. At the top of your wallet, change from "Ethereum Main Network" to "Ropsten Test Network"
 4. At the bottom of your wallet, select "Import Tokens" 
-5. For "Token Address" paste `0x1d45b83af7e69209108c1f91d5955fc1aef7737b`
-6. Send and receive KEGs!
+5. For "Token Address" paste `` (KEG)
+6. Repeate this for PINTs with address `` (PINT)
+7. Send and receive KEG & PINTs!
 
 If you don't have enough Eth for gas, request some here: https://faucet.ropsten.be/
 
 # Tokenomics 
 
-The brewer controls the Keg Token supply. Keg Tokens can be issued by the brewer. Every token is backed by, and redeamable for, one keg of beer. 
+The brewer controls the Beer Token supply. Beer Tokens can be issued by the brewer. Every token is **backed by beer**.
 
 # Technical Details
 
 Currently setup on the Ropsten test network.
 
-- Ropsten contract: https://ropsten.etherscan.io/token/0x1d45b83af7e69209108c1f91d5955fc1aef7737b
+- Keg contract: https://ropsten.etherscan.io/token/0x1d45b83af7e69209108c1f91d5955fc1aef7737b
 
-- Brewery Transactions: https://ropsten.etherscan.io/token/0x1d45b83af7e69209108c1f91d5955fc1aef7737b?a=0xedb31a4e1ba43701402d60dcb089a0bae0181ddf
+- Pint contract: 
 
-- Contract Deployment Hash: 0x03509C9F6efB20F70181405DEd5FE1a0f52216D9
+- Brewer: https://ropsten.etherscan.io/token/0x1d45b83af7e69209108c1f91d5955fc1aef7737b?a=0xedb31a4e1ba43701402d60dcb089a0bae0181ddf
+
+- Keg contract deployment hash: 0x03509C9F6efB20F70181405DEd5FE1a0f52216D9
+
+- Pint contract deployment hash:
 
 - Eth Contract IDE: https://remix.ethereum.org/

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Every Pint Token (PINT) is redeamable for a 1 pint from a keg.
 2. Setup Metamask wallet
 3. At the top of your wallet, change from "Ethereum Main Network" to "Ropsten Test Network"
 4. At the bottom of your wallet, select "Import Tokens" 
-5. For "Token Address" paste `` (KEG)
-6. Repeate this for PINTs with address `` (PINT)
-7. Send and receive KEG & PINTs!
+5. For "Token Address" paste `0x1b12242029405ceb7e1c672e9a6e3c784c1b1865` this is the address for Pint Tokens (PINT)
+6. *Optional:* Repeate this for KEGs with address `0xf9c4989687a456b40573f0c3b655f3307f24b40a` (KEG)
+7. Send and receive PINTs!
 
 If you don't have enough Eth for gas, request some here: https://faucet.ropsten.be/
 
@@ -28,14 +28,14 @@ The brewer controls the Beer Token supply. Beer Tokens can be issued by the brew
 
 Currently setup on the Ropsten test network.
 
-- Keg contract: https://ropsten.etherscan.io/token/0x1d45b83af7e69209108c1f91d5955fc1aef7737b
+- Keg contract: https://ropsten.etherscan.io/token/0xf9c4989687a456b40573f0c3b655f3307f24b40a
 
-- Pint contract: 
+- Pint contract: https://ropsten.etherscan.io/token/0x1b12242029405ceb7e1c672e9a6e3c784c1b1865
 
 - Brewer: https://ropsten.etherscan.io/token/0x1d45b83af7e69209108c1f91d5955fc1aef7737b?a=0xedb31a4e1ba43701402d60dcb089a0bae0181ddf
 
-- Keg contract deployment hash: 0x03509C9F6efB20F70181405DEd5FE1a0f52216D9
+- Keg contract deployment hash: 0xF9C4989687a456b40573F0C3B655F3307f24B40a
 
-- Pint contract deployment hash:
+- Pint contract deployment hash: 0x1B12242029405ceb7e1C672E9A6E3c784c1b1865
 
 - Eth Contract IDE: https://remix.ethereum.org/

--- a/beer-token.sol
+++ b/beer-token.sol
@@ -15,25 +15,21 @@ contract BeerToken is ERC20 {
     // Number of decimal places for the token
     uint8 decimalPlaces;
 
-    // Name of the token "My Beer Token"
-    string tokenName;
-
-    // Short code for the token "MBT"
-    string tokenCode;
-
-    // Number of tokens originally brewed during contract creation 
-    uint256 tokenCount;
-
+    /* Contstructor for BeerToken
+    * 
+    * params:
+    * _tokenName = Name of the token "My Beer Token"
+    * _tokenCode = Short code for the token "MBT"
+    * _tokenCount = Number of beers originally brewed during contract creation 
+    * _decimalPlaces = How divisible your beer is 
+    */
 
     constructor(string memory _tokenName, string memory _tokenCode, uint256 _tokenCount, uint8  _decimalPlaces) ERC20(_tokenName, _tokenCode) {   
-        tokenName = _tokenName;
-        tokenCode = _tokenCode;
-        tokenCount = _tokenCount;
         decimalPlaces = _decimalPlaces;
 
         // set the brewer to the contract creator
         brewer = msg.sender;
-        _mint(brewer, tokenCount * 10 ** decimalPlaces);
+        _mint(brewer, _tokenCount * 10 ** decimalPlaces);
     }
 
     // allow the brewer to mint new tokens for himself

--- a/beer-token.sol
+++ b/beer-token.sol
@@ -25,7 +25,7 @@ contract BeerToken is ERC20 {
     uint256 tokenCount;
 
 
-    constructor(string _tokenName, string _tokenCode, string _tokenCount, uint8 _decimalPlaces) public {   
+    constructor(string memory _tokenName, string memory _tokenCode, uint256 _tokenCount, uint8  _decimalPlaces) ERC20(_tokenName, _tokenCode) {   
         tokenName = _tokenName;
         tokenCode = _tokenCode;
         tokenCount = _tokenCount;
@@ -34,9 +34,6 @@ contract BeerToken is ERC20 {
         // set the brewer to the contract creator
         brewer = msg.sender;
         _mint(brewer, tokenCount * 10 ** decimalPlaces);
-
-        // create ERC20 token
-        super(tokenName, tokenCode);
     }
 
     // allow the brewer to mint new tokens for himself

--- a/beer-token.sol
+++ b/beer-token.sol
@@ -1,0 +1,64 @@
+pragma solidity ^0.8.7;
+
+// Base ERC20 implementation from OpenZepplin
+import 'https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol';
+
+
+contract BeerToken is ERC20 {
+
+    // Address of the brewer who brews beer
+    address public brewer;
+
+    // Message to send when someone tries to do something only the brewer should be able to do
+    string rejectMessage = 'No no no, only the brewer.';
+
+    // Number of decimal places for the token
+    uint8 decimalPlaces;
+
+    // Name of the token "My Beer Token"
+    string tokenName;
+
+    // Short code for the token "MBT"
+    string tokenCode;
+
+    // Number of tokens originally brewed during contract creation 
+    uint256 tokenCount;
+
+
+    constructor(string _tokenName, string _tokenCode, string _tokenCount, uint8 _decimalPlaces) public {   
+        tokenName = _tokenName;
+        tokenCode = _tokenCode;
+        tokenCount = _tokenCount;
+        decimalPlaces = _decimalPlaces;
+
+        // set the brewer to the contract creator
+        brewer = msg.sender;
+        _mint(brewer, tokenCount * 10 ** decimalPlaces);
+
+        // create ERC20 token
+        super(tokenName, tokenCode);
+    }
+
+    // allow the brewer to mint new tokens for himself
+    function brewBeer(uint amount) external {
+        require(msg.sender == brewer, rejectMessage);
+        _mint(brewer, amount);
+    }
+
+    // allow the brewer to assign a new brewer
+    function changeBrewer(address newBrewer) external {
+        require(msg.sender == brewer, rejectMessage);
+        brewer = newBrewer;
+    }
+    
+    // allow the brewer to take back anyone's tokens
+    function revokeBeer(address account, uint amount) external {
+        require(msg.sender == brewer, rejectMessage);
+        _transfer(account, brewer, amount);
+    }
+    
+    // Show how many decimals the token has
+    function decimals() public view override returns (uint8) {
+        return decimalPlaces;
+    }
+}

--- a/beer-token.sol
+++ b/beer-token.sol
@@ -17,6 +17,8 @@ contract BeerToken is ERC20 {
 
     /* Contstructor for BeerToken
     * 
+    * This creates a new ERC20 compliant token
+    * 
     * params:
     * _tokenName = Name of the token "My Beer Token"
     * _tokenCode = Short code for the token "MBT"

--- a/keg-token.sol
+++ b/keg-token.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.8.7;
 
-// Base ERC20 implementation from OpenZepplin
-import 'https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol';
+// Base BeerToken
+import './beer-token.sol';
 
 contract KegToken is BeerToken {
 

--- a/keg-token.sol
+++ b/keg-token.sol
@@ -3,13 +3,8 @@ pragma solidity ^0.8.7;
 // Base BeerToken
 import './beer-token.sol';
 
-contract KegToken is BeerToken {
-
-    // Number of tokens minted at contract creation time
-    uint256 orginalKegCount = 10;
-
-    constructor() BeerToken('Keg Tokens', 'KEG', orginalKegCount, 2){
- 
-    }
+contract KegToken is BeerToken('Keg Tokens', 'KEG', 10, 2) {
+    
+    constructor() {}
     
 }

--- a/keg-token.sol
+++ b/keg-token.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.7;
 // Base BeerToken
 import './beer-token.sol';
 
+//Let's create a BeerToken for tracking KEGs with an initial supply of 10 KEGs which can be divided by 2 decimal places
 contract KegToken is BeerToken('Keg Tokens', 'KEG', 10, 2) {
     
     constructor() {}

--- a/pint-token.sol
+++ b/pint-token.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.8.7;
 
-// Base ERC20 implementation from OpenZepplin
-import 'https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol';
+// Base BeerToken
+import './beer-token.sol';
 
 contract PintToken is BeerToken {
 

--- a/pint-token.sol
+++ b/pint-token.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.7;
 // Base ERC20 implementation from OpenZepplin
 import 'https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol';
 
-contract KegToken is BeerToken {
+contract PintToken is BeerToken {
 
     // Number of tokens minted at contract creation time
-    uint256 orginalKegCount = 10;
+    uint256 orginalPintCount = 1000;
 
-    constructor() BeerToken('Keg Tokens', 'KEG', orginalKegCount, 2){
+    constructor() BeerToken('Pint Tokens', 'PINT', orginalPintCount, 0){
  
     }
     

--- a/pint-token.sol
+++ b/pint-token.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.7;
 // Base BeerToken
 import './beer-token.sol';
 
+//Lets create a BeerToken for tracking PINTs with an intial supply of 1000 PINTs and no decimal places
 contract PintToken is BeerToken('Pint Tokens', 'PINT', 1000, 0) {
     
     constructor() {}

--- a/pint-token.sol
+++ b/pint-token.sol
@@ -3,13 +3,8 @@ pragma solidity ^0.8.7;
 // Base BeerToken
 import './beer-token.sol';
 
-contract PintToken is BeerToken {
-
-    // Number of tokens minted at contract creation time
-    uint256 orginalPintCount = 1000;
-
-    constructor() BeerToken('Pint Tokens', 'PINT', orginalPintCount, 0){
- 
-    }
+contract PintToken is BeerToken('Pint Tokens', 'PINT', 1000, 0) {
+    
+    constructor() {}
     
 }


### PR DESCRIPTION
Create pint tokens.

There are now two classes which inherit from the base Beer Token. 

Kegs and Pints are issued based on the original Beer Token contract. The only difference is how many tokens are issues, and the token name.